### PR TITLE
Refactor common Layer prop/methods

### DIFF
--- a/lib/aeris/maps/base/layers/aerisinteractivetile.js
+++ b/lib/aeris/maps/base/layers/aerisinteractivetile.js
@@ -29,6 +29,12 @@ define(['aeris', './tile'], function(aeris) {
     /**
      * @override
      */
+    this.server = 'http://tile{d}.aerisapi.com/';
+
+
+    /**
+     * @override
+     */
     this.minZoom = 0;
 
 
@@ -76,6 +82,46 @@ define(['aeris', './tile'], function(aeris) {
   aeris.inherits(aeris.maps.layers.AerisInteractiveTile,
                  aeris.maps.layers.Tile);
 
+
+  /**
+   * @override
+   */
+  aeris.maps.layers.AerisInteractiveTile.prototype.getUrl = function() {
+    return this.server +
+        aeris.config.apiId + '_' +
+        aeris.config.apiSecret +
+        '/' + this.tileType +
+        '/{z}/{x}/{y}/{t}.png';
+  }
+
+
+  /**
+   * @override
+   */
+  aeris.maps.layers.AerisInteractiveTile.prototype.clone = function(properties) {
+    var LayerType, cloned;
+    LayerType = aeris.maps.layers[this.name];
+
+    if(!LayerType) {
+      throw new Error("Unable to clone Layer: Invalid layer");
+    }
+
+    cloned = new LayerType();
+
+    if(!(cloned instanceof aeris.maps.Layer)) {
+      throw new Error("Unable to clone Layer: layer must be instance of aeris.maps.layers.Layer");
+    }
+
+    for (var k in this) {
+      if (typeof this[k] != 'function' && k != 'id') {
+        cloned[k] = this[k];
+      }
+    }
+    cloned.clear();
+    aeris.extend(cloned, properties);
+    cloned.setMap(this.getMap());
+    return cloned;
+  };
 
   return aeris.maps.layers.AerisInteractiveTile;
 

--- a/lib/aeris/maps/base/layers/aerisradar.js
+++ b/lib/aeris/maps/base/layers/aerisradar.js
@@ -33,15 +33,6 @@ define(['aeris', './aerisinteractivetile'], function(aeris) {
     /**
      * @override
      */
-    this.url = 'http://tile{d}.aerisapi.com/' +
-               aeris.config.apiId + '_' +
-               aeris.config.apiSecret +
-               '/radar/{z}/{x}/{y}/{t}.png';
-
-
-    /**
-     * @override
-     */
     this.zIndex = 2;
 
   };
@@ -49,22 +40,6 @@ define(['aeris', './aerisinteractivetile'], function(aeris) {
                  aeris.maps.layers.AerisInteractiveTile);
 
 
-  /**
-   * @override
-   */
-  aeris.maps.layers.AerisRadar.prototype.clone =
-      function(properties) {
-    var cloned = new aeris.maps.layers.AerisRadar();
-    for (var k in this) {
-      if (typeof this[k] != 'function' && k != 'id') {
-        cloned[k] = this[k];
-      }
-    }
-    cloned.clear();
-    aeris.extend(cloned, properties);
-    cloned.setMap(this.getMap());
-    return cloned;
-  };
 
 
   return aeris.maps.layers.AerisRadar;

--- a/lib/aeris/maps/base/layers/aerissatellite.js
+++ b/lib/aeris/maps/base/layers/aerissatellite.js
@@ -29,36 +29,10 @@ define(['aeris', './aerisinteractivetile'], function(aeris) {
      */
     this.tileType = 'sat';
 
-
-    /**
-     * @override
-     */
-    this.url = 'http://tile{d}.aerisapi.com/' +
-               aeris.config.apiId + '_' +
-               aeris.config.apiSecret +
-               '/sat/{z}/{x}/{y}/{t}.png';
-
   };
   aeris.inherits(aeris.maps.layers.AerisSatellite,
                  aeris.maps.layers.AerisInteractiveTile);
 
-
-  /**
-   * @override
-   */
-  aeris.maps.layers.AerisSatellite.prototype.clone =
-      function(properties) {
-    var cloned = new aeris.maps.layers.AerisSatellite();
-    for (var k in this) {
-      if (typeof this[k] != 'function' && k != 'id') {
-        cloned[k] = this[k];
-      }
-    }
-    cloned.clear();
-    aeris.extend(cloned, properties);
-    cloned.setMap(this.getMap());
-    return cloned;
-  };
 
 
   return aeris.maps.layers.AerisSatellite;

--- a/lib/aeris/maps/base/layers/kml.js
+++ b/lib/aeris/maps/base/layers/kml.js
@@ -12,7 +12,7 @@ define(['aeris', 'base/layer'], function(aeris) {
    * Representation of KML layer.
    *
    * @constructor
-   * @extends {aeris.maps.Layers}
+   * @extends {aeris.maps.Layer}
    */
   aeris.maps.layers.KML = function() {
     aeris.maps.Layer.call(this);

--- a/lib/aeris/maps/base/layers/osm.js
+++ b/lib/aeris/maps/base/layers/osm.js
@@ -34,11 +34,10 @@ define(['aeris', './tile'], function(aeris) {
      */
     this.subdomains = ['a', 'b', 'c'];
 
-
     /**
      * @override
      */
-    this.url = 'http://{d}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    this.server = 'http://{d}.tile.openstreetmap.org/';
 
 
     /**
@@ -54,6 +53,14 @@ define(['aeris', './tile'], function(aeris) {
 
   };
   aeris.inherits(aeris.maps.layers.OSM, aeris.maps.layers.Tile);
+
+
+  /**
+   * @override
+   */
+  aeris.maps.layers.OSM.prototype.getUrl = function() {
+    return this.server + '{z}/{x}/{y}.png';
+  };
 
 
   return aeris.maps.layers.OSM;

--- a/lib/aeris/maps/base/layers/tile.js
+++ b/lib/aeris/maps/base/layers/tile.js
@@ -26,22 +26,16 @@ define(['aeris', 'base/layer'], function(aeris) {
      */
     this.subdomains = [];
 
-
     /**
-     * The url for requesting tiles. The url will be interpolated by replacing
+     * The server used for requesting tiles. The server will be interpolated by replacing
      * special variables with calculated values. Special variables should be
-     * wrapped with '{' and '}'.
+     * wrapped with '{' and '}'
      *
      * * {d} - a randomly selected subdomain
-     * * {z} - the calculated zoom factor
-     * * {x} - the tile's starting x coordinate
-     * * {y} - the tile's starting y coordinate
-     * 
-     * ex. http://{d}.tileserver.net/{z}/{x}/{y}.png
      *
      * @type {string}
      */
-    this.url = null;
+    this.server = null;
 
 
     /**
@@ -61,6 +55,23 @@ define(['aeris', 'base/layer'], function(aeris) {
 
   };
   aeris.inherits(aeris.maps.layers.Tile, aeris.maps.Layer);
+
+  /**
+   * Returns the url for requesting tiles. The url will be interpolated by replacing
+   * special variables with calculated values. Special variables should be
+   * wrapped with '{' and '}'.
+   *
+   * * {d} - a randomly selected subdomain
+   * * {z} - the calculated zoom factor
+   * * {x} - the tile's starting x coordinate
+   * * {y} - the tile's starting y coordinate
+   *
+   * ex. http://{d}.tileserver.net/{z}/{x}/{y}.png
+   *
+   * @type {string}
+   * @return {string} default url for tile image
+   */
+  aeris.maps.layers.Tile.prototype.getUrl = aeris.abstractMethod;
 
 
   /**

--- a/lib/aeris/maps/gmaps/layerstrategies/tile.js
+++ b/lib/aeris/maps/gmaps/layerstrategies/tile.js
@@ -129,7 +129,7 @@ define(['aeris', 'base/layerstrategy', './mixins/div'], function(aeris) {
     var subdomain = layer.subdomains[Math.floor(Math.random() *
                                                 layer.subdomains.length)];
 
-    var url = layer.url
+    var url = layer.getUrl();
     url = url.replace(/\{d\}/, subdomain);
     url = url.replace(/\{z\}/, zfactor);
     url = url.replace(/\{x\}/, coord.x);

--- a/lib/aeris/maps/openlayers/layerstrategies/tile.js
+++ b/lib/aeris/maps/openlayers/layerstrategies/tile.js
@@ -59,7 +59,7 @@ define(['aeris', 'base/layerstrategy', './mixins/default'], function(aeris) {
     var length = layer.subdomains.length;
     for (var i = 0; i < length; i++) {
       var subdomain = layer.subdomains[i];
-      var url = layer.url;
+      var url = layer.getUrl();
       url = url.replace(/\{d\}/, subdomain);
       url = url.replace(/\{z\}/, '${z}');
       url = url.replace(/\{x\}/, '${x}');


### PR DESCRIPTION
- Move clone method to AerisInteractiveTile base class
  uses tile `name` prop to determine layer class
- Move default Tile url definition to
  base Tile class
  using generateUrl method
- Fix missing semicolon
